### PR TITLE
Depend on real typoscript rendering package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=5.6.0",
         "typo3/cms-core": "^6.2 || ^7.6 || ^8.7",
-        "typo3-ter/typoscript-rendering": "^2.0"
+        "helhum/typoscript-rendering": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Instead of depending on the composer.typo3.org
version, depend on the version on Packagist